### PR TITLE
add patch for PyTorch 1.7.1 to fix undefined __ieee128 identifier on CentOS 8

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.7.1-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.7.1-fosscuda-2019b-Python-3.7.4.eb
@@ -246,6 +246,7 @@ patches = [
     'PyTorch-1.7.0_avoid-nan-in-test-torch.patch',
     'PyTorch-1.7.0_increase-distributed-test-timeout.patch',
     'PyTorch-1.7.0_disable-dev-shm-test.patch',
+    'PyTorch-1.7.1_el8_ppc64le.patch',
 ]
 checksums = [
     'fc8d6aaf0bdedd4221617be8d47ac39af57605bdcc814fabc28739427b55e9c7',  # v1.7.1.tar.gz
@@ -295,6 +296,7 @@ checksums = [
     # PyTorch-1.7.0_increase-distributed-test-timeout.patch
     'c94eda2289692d00873e2ae8cecaaf7a1e5e657dfa4cfcd94b56093f6f4766ad',
     '622cb1eaeadc06e13128a862d9946bcc1f1edd3d02b259c56a9aecc4d5406b8a',  # PyTorch-1.7.0_disable-dev-shm-test.patch
+    '2a94a9cc009f02469b843fc65a6ee2cb01873f783568b8bcc83c33ba8e6b1a58',  # PyTorch-1.7.1_el8_ppc64le.patch
 ]
 
 excluded_tests = {

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.7.1_el8_ppc64le.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.7.1_el8_ppc64le.patch
@@ -1,0 +1,27 @@
+fix, on ppc64le and RHEL / CentOS 8, for: identifier "__ieee128" is undefined
+See https://github.com/easybuilders/easybuild-easyconfigs/issues/11913
+Patch by Simon Branford (University of Birmingham), ported to PyTorch 1.7.1 by Kenneth Hoste (HPC-UGent)
+--- pytorch-1.7.1/cmake/Dependencies.cmake.orig	2020-12-07 19:28:38.000000000 +0000
++++ pytorch-1.7.1/cmake/Dependencies.cmake	2021-01-10 14:09:00.593547793 +0000
+@@ -1501,6 +1501,9 @@
+   if(CMAKE_POSITION_INDEPENDENT_CODE AND NOT MSVC)
+     list(APPEND CUDA_NVCC_FLAGS "-Xcompiler" "-fPIC")
+   endif()
++  if(CMAKE_SYSTEM_PROCESSOR MATCHES "(powerpc|ppc)64le")
++    list(APPEND CUDA_NVCC_FLAGS "-Xcompiler" "-mno-float128")
++  endif()
+ 
+   if(CUDA_HAS_FP16 OR NOT ${CUDA_VERSION} LESS 7.5)
+     message(STATUS "Found CUDA with FP16 support, compiling with torch.cuda.HalfTensor")
+--- pytorch-1.7.1/third_party/gloo/cmake/Cuda.cmake.orig	2021-01-10 14:09:00.593547793 +0000
++++ pytorch-1.7.1/third_party/gloo/cmake/Cuda.cmake	2021-01-10 14:11:36.177738536 +0000
+@@ -177,5 +177,9 @@
+   gloo_list_append_if_unique(CUDA_NVCC_FLAGS "-Xcompiler" "-fPIC")
+ endif()
+ 
++if(CMAKE_SYSTEM_PROCESSOR MATCHES "(powerpc|ppc)64le")
++  gloo_list_append_if_unique(CUDA_NVCC_FLAGS "-Xcompiler" "-mno-float128")
++endif()
++
+ mark_as_advanced(CUDA_BUILD_CUBIN CUDA_BUILD_EMULATION CUDA_VERBOSE_BUILD)
+ mark_as_advanced(CUDA_SDK_ROOT_DIR CUDA_SEPARABLE_COMPILATION)


### PR DESCRIPTION
for https://github.com/easybuilders/easybuild-easyconfigs/pull/11636