### PR TITLE
add patches for jaxlib and jax to fix/skip failing tests + use 'CUDA_VISIBLE_DEVICES=0 JAX_ENABLE_X64=true' for running jax tests

### DIFF
--- a/easybuild/easyconfigs/j/jax/jax-0.2.19-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/j/jax/jax-0.2.19-fosscuda-2020b.eb
@@ -64,6 +64,7 @@ components = [
         'patches': [
             '%(name)s-%(version)s_add-bazel-args-to-shutdown.patch',
             '%(name)s-%(version)s_no-tensorflow-download.patch',
+            '%(name)s-%(version)s_fix-gpu-translation-rule.patch',
             ('TensorFlow-%s_mlir-build-env.patch' % local_tf_commit, '../' + local_tf_dir),
             ('TensorFlow-2.1.0_fix-cuda-build.patch', '../' + local_tf_dir),
         ],
@@ -76,6 +77,8 @@ components = [
             'c0ea6abd7827d3c37bdd60c30c7b0613fc86b91274c6a1a4cf13a3c7f9ce7631',
             # jaxlib-0.1.70_no-tensorflow-download.patch
             '1496c6be9336fb563b997f8da83d690a9b3a0a6e29fdd87fac60409300a2fd95',
+            # jaxlib-0.1.70_fix-gpu-translation-rule.patch
+            'ce3cf8ee3b393f6580fb88bc39cc2660be46f2a48a315a3779403725ad49f946',
             # TensorFlow-4039feeb743bc42cd0a3d8146ce63fc05d23eb8d-build-env.patch
             'd067836b1d18d66a8c69fb3db311855c8a56c0106d42a11299a1733c385e9c22',
             # TensorFlow-2.1.0_fix-cuda-build.patch
@@ -93,8 +96,19 @@ exts_list = [
     (name, version, {
         'source_tmpl': '%(name)s-v%(version)s.tar.gz',
         'source_urls': ['https://github.com/google/jax/archive/'],
-        'checksums': ['fb6f665b1461ac67954c1004da00d12e1c41b65b744a5fa0311d26d1a784a96c'],
-        'runtest': 'pytest -n %(parallel)s tests',
+        'patches': ['jax-%(version)s_skip-heap-profiler-test.patch'],
+        'checksums': [
+            'fb6f665b1461ac67954c1004da00d12e1c41b65b744a5fa0311d26d1a784a96c',  # jax-v0.2.19.tar.gz
+            # jax-0.2.19_skip-heap-profiler-test.patch
+            'a431ce1b6588b5098872f36575dc2c5023b1010760bf6aaa889125c9a09227b0',
+        ],
+        # deliberately not testing in parallel, as that results in (additional) failing tests;
+        # use XLA_PYTHON_CLIENT_ALLOCATOR=platform when running GPU tests in parallel,
+        # to avoid each test fully allocating the GPU memory...,
+        # see https://github.com/google/jax/issues/7323 and
+        # https://github.com/google/jax/blob/main/docs/gpu_memory_allocation.rst;
+        # use CUDA_VISIBLE_DEVICES=0 to avoid failing tests on systems with multiple GPUs;
+        'runtest': 'CUDA_VISIBLE_DEVICES=0 JAX_ENABLE_X64=true pytest tests',
     }),
 ]
 

--- a/easybuild/easyconfigs/j/jax/jax-0.2.19_skip-heap-profiler-test.patch
+++ b/easybuild/easyconfigs/j/jax/jax-0.2.19_skip-heap-profiler-test.patch
@@ -1,0 +1,14 @@
+skip this test with jax 0.2.19 + jaxlib 0.1.70, since it's broken:
+RuntimeError: Invalid argument: GetOnDeviceSizeInBytes called on deleted or donated buffer
+author: Kenneth Hoste (HPC-UGent)
+--- jax-jax-v0.2.19/tests/heap_profiler_test.py.orig	2021-08-21 14:50:01.396950980 +0200
++++ jax-jax-v0.2.19/tests/heap_profiler_test.py	2021-08-21 14:50:17.368215928 +0200
+@@ -27,7 +27,7 @@
+   # These tests simply test that the heap profiler API does not crash; they do
+   # not check functional correctness.
+ 
+-  def testBasics(self):
++  def disabled_testBasics(self):
+     client = jax.lib.xla_bridge.get_backend()
+     _ = client.heap_profile()
+ 

--- a/easybuild/easyconfigs/j/jax/jaxlib-0.1.70_fix-gpu-translation-rule.patch
+++ b/easybuild/easyconfigs/j/jax/jaxlib-0.1.70_fix-gpu-translation-rule.patch
@@ -1,0 +1,100 @@
+see https://github.com/google/jax/pull/7560
+
+From f8081a9a529e82e6390275491b2c6d6becbb3283 Mon Sep 17 00:00:00 2001
+From: Jake VanderPlas <jakevdp@google.com>
+Date: Tue, 10 Aug 2021 10:13:29 -0700
+Subject: [PATCH] [sparse] fix GPU translation rule for coo/csr matmat
+
+---
+ jaxlib/cusparse.py   | 12 ++++++------
+ tests/sparse_test.py | 18 +++++++++++++++++-
+ 2 files changed, 23 insertions(+), 7 deletions(-)
+
+diff --git a/jaxlib/cusparse.py b/jaxlib/cusparse.py
+index 6264c7ba48..7e0adf21a1 100644
+--- a/jaxlib/cusparse.py
++++ b/jaxlib/cusparse.py
+@@ -137,8 +137,9 @@ def csr_matmat(c, data, indices, indptr, B, *, shape, transpose=False, compute_d
+   dtype = np.dtype(c.get_shape(data).element_type())
+   index_dtype = np.dtype(c.get_shape(indices).element_type())
+   B_dtype = np.dtype(c.get_shape(B).element_type())
++  B_shape = c.get_shape(B).dimensions()
+   rows, cols = shape
+-  _, Ccols = c.get_shape(B).dimensions()
++  _, Ccols = B_shape
+   nnz, = c.get_shape(data).dimensions()
+ 
+   if compute_dtype is None:
+@@ -154,11 +155,10 @@ def csr_matmat(c, data, indices, indptr, B, *, shape, transpose=False, compute_d
+       b"cusparse_csr_matmat",
+       operands=(data, indices, indptr, B),
+       operand_shapes_with_layout=(
+-          # All are 1D, so no layout necessary
+           c.get_shape(data),
+           c.get_shape(indices),
+           c.get_shape(indptr),
+-          c.get_shape(B),
++          _Shape.array_shape(B_dtype, B_shape, (1, 0)),
+       ),
+       shape_with_layout=_Shape.tuple_shape((
+           _Shape.array_shape(compute_dtype, (out_size, Ccols), (1, 0)),
+@@ -272,8 +272,9 @@ def coo_matmat(c, data, row, col, B, *, shape, transpose=False, compute_dtype=No
+   dtype = np.dtype(c.get_shape(data).element_type())
+   index_dtype = np.dtype(c.get_shape(row).element_type())
+   B_dtype = np.dtype(c.get_shape(B).element_type())
++  B_shape = c.get_shape(B).dimensions()
+   rows, cols = shape
+-  _, Ccols = c.get_shape(B).dimensions()
++  _, Ccols = B_shape
+   nnz, = c.get_shape(data).dimensions()
+ 
+   if compute_dtype is None:
+@@ -289,11 +290,10 @@ def coo_matmat(c, data, row, col, B, *, shape, transpose=False, compute_dtype=No
+       b"cusparse_coo_matmat",
+       operands=(data, row, col, B),
+       operand_shapes_with_layout=(
+-          # All are 1D, so no layout necessary
+           c.get_shape(data),
+           c.get_shape(row),
+           c.get_shape(col),
+-          c.get_shape(B),
++          _Shape.array_shape(B_dtype, B_shape, (1, 0)),
+       ),
+       shape_with_layout=_Shape.tuple_shape((
+           _Shape.array_shape(compute_dtype, (out_size, Ccols), (1, 0)),
+diff --git a/tests/sparse_test.py b/tests/sparse_test.py
+index 993d995afd..af30e27aec 100644
+--- a/tests/sparse_test.py
++++ b/tests/sparse_test.py
+@@ -202,7 +202,6 @@ def test_coo_matvec(self, shape, dtype, transpose):
+     self.assertAllClose(op(M) @ v, matvec(*args), rtol=MATMUL_TOL)
+     self.assertAllClose(op(M) @ v, jit(matvec)(*args), rtol=MATMUL_TOL)
+ 
+-  @unittest.skipIf(jtu.device_under_test() != "gpu", "test requires GPU")
+   @parameterized.named_parameters(jtu.cases_from_list(
+       {"testcase_name": "_{}_T={}".format(jtu.format_shape_dtype_string(shape, dtype), transpose),
+        "shape": shape, "dtype": dtype, "transpose": transpose}
+@@ -229,6 +228,23 @@ def test_coo_matmat(self, shape, dtype, transpose):
+     y, dy = jvp(lambda x: sparse.coo_matmat(x, M.row, M.col, B, shape=shape, transpose=transpose).sum(), (M.data, ), (jnp.ones_like(M.data), ))
+     self.assertAllClose((op(M) @ B).sum(), y, rtol=MATMUL_TOL)
+ 
++  def test_coo_matmat_layout(self):
++    # Regression test for https://github.com/google/jax/issues/7533
++    d = jnp.array([1.0, 2.0, 3.0, 4.0])
++    i = jnp.array([0, 0, 1, 2])
++    j = jnp.array([0, 2, 0, 0])
++    shape = (3, 3)
++
++    x = jnp.arange(9).reshape(3, 3).astype(d.dtype)
++
++    def f(x):
++      return sparse.coo_matmat(d, i, j, x.T, shape=shape)
++
++    result = f(x)
++    result_jit = jit(f)(x)
++
++    self.assertAllClose(result, result_jit)
++
+   @unittest.skipIf(jtu.device_under_test() != "gpu", "test requires GPU")
+   def test_gpu_translation_rule(self):
+     version = xla_bridge.get_backend().platform_version


### PR DESCRIPTION
@Flamefire for https://github.com/easybuilders/easybuild-easyconfigs/pull/13760