### PR TITLE
limit parallelism to 10 for jax with foss/2020b, to avoid failing tests because not enough threads can be started

### DIFF
--- a/easybuild/easyconfigs/j/jax/jax-0.2.19-foss-2020b.eb
+++ b/easybuild/easyconfigs/j/jax/jax-0.2.19-foss-2020b.eb
@@ -34,6 +34,10 @@ local_jax_prebuildopts = "sed -i 's$pathToSed$%s$g' WORKSPACE && " % local_tf_bu
 
 use_pip = True
 
+# running the tests with lots of cores results in test failures because not enough threads can be started,
+# so limit to a reasonable number of cores to use at maximum
+maxparallel = 10
+
 default_easyblock = 'PythonPackage'
 default_component_specs = {
     'sources': [SOURCE_TAR_GZ],


### PR DESCRIPTION
@Flamefire for https://github.com/easybuilders/easybuild-easyconfigs/pull/13760, to avoid the failing tests I'm running into when using 36 cores for running the tests, cfr. https://github.com/easybuilders/easybuild-easyconfigs/pull/13760#issuecomment-907046372